### PR TITLE
fix: disable live poll on tasks pages to prevent form state loss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fix `retry` option validation to accept integer values.
 - Add `retry_for` option support (Sidekiq 7.1.3+).
 - Fix `find_by` to use exact name matching instead of fuzzy matching.
+- Disable live poll on tasks pages to prevent form state loss (Sidekiq >= 7.0.1).
 
 ### [0.1.7] - 2025-07-27
 

--- a/lib/sidekiq/tasks/web.rb
+++ b/lib/sidekiq/tasks/web.rb
@@ -6,6 +6,7 @@ module Sidekiq
       autoload :Extension, "sidekiq/tasks/web/extension"
 
       ROOT = File.expand_path("../../../web", File.dirname(__FILE__))
+      SIDEKIQ_GTE_7_0_1 = Gem::Version.new(Sidekiq::VERSION) >= Gem::Version.new("7.0.1")
       SIDEKIQ_GTE_7_3_0 = Gem::Version.new(Sidekiq::VERSION) >= Gem::Version.new("7.3.0")
       SIDEKIQ_GTE_8_0_0 = Gem::Version.new(Sidekiq::VERSION) >= Gem::Version.new("8.0.0")
     end

--- a/lib/sidekiq/tasks/web/helpers/application_helper.rb
+++ b/lib/sidekiq/tasks/web/helpers/application_helper.rb
@@ -25,6 +25,12 @@ module Sidekiq
             keys.to_h { |key| [key.to_sym, fetch_param(key)] }
           end
 
+          def pollable?
+            return false if current_path.start_with?("tasks")
+
+            super
+          end
+
           def authorize!
             return if Sidekiq::Tasks.config.authorization.call(env)
 

--- a/spec/features/task_spec.rb
+++ b/spec/features/task_spec.rb
@@ -14,6 +14,14 @@ RSpec.describe "Task page", type: :feature do
     )
   end
 
+  it(
+    "does not display the live poll button",
+    skip: !Sidekiq::Tasks::Web::SIDEKIQ_GTE_7_0_1 && "requires Sidekiq >= 7.0.1"
+  ) do
+    visit "/tasks/tests-task_with_args"
+    expect(page).not_to have_css(".live-poll-start", visible: :all)
+  end
+
   it "display error when task not found" do
     visit "/tasks/unknown"
     expect(page).to have_content("Task not found")

--- a/spec/features/tasks_spec.rb
+++ b/spec/features/tasks_spec.rb
@@ -13,6 +13,14 @@ RSpec.describe "Tasks page", type: :feature do
     )
   end
 
+  it(
+    "does not display the live poll button",
+    skip: !Sidekiq::Tasks::Web::SIDEKIQ_GTE_7_0_1 && "requires Sidekiq >= 7.0.1"
+  ) do
+    visit "/tasks"
+    expect(page).not_to have_css(".live-poll-start", visible: :all)
+  end
+
   it "displays the tasks list" do
     visit "/tasks"
 


### PR DESCRIPTION
Resolves #16 